### PR TITLE
Check and update both components on start

### DIFF
--- a/etc/init.d/qosmate
+++ b/etc/init.d/qosmate
@@ -6,8 +6,8 @@ STOP=99
 
 USE_PROCD=1
 
-VERSION="dev"
-UPD_CHANNEL="release"
+VERSION="13062ae883c58e2aa99040993af0f980e2092466"
+UPD_CHANNEL="snapshot"
 
 EXTRA_COMMANDS="check_version update auto_setup expand_config auto_setup_noninteractive validate_custom_rules health_check"
 EXTRA_HELP="
@@ -1057,18 +1057,25 @@ start_service() {
 		. "${QOSMATE_SERVICE_PATH}" # source updated init script 
 	fi
 
-    check_files_integrity BACKEND
-    case $? in
-        0) ;; # integrity OK
-        1) return 1 ;;
-        2) # missing files
-			case "$VERSION" in
-				dev|''|"1.1.0"|"v1.1.0") ;;
-				*) force_version="-W $VERSION"
-			esac
-            update -n -U "$UPD_CHANNEL" $force_version -c BACKEND || return 1 ;;
-        3) ;; # non-matching md5sums
-    esac
+    for component in $QOSMATE_COMPONENTS; do
+        check_files_integrity "$component"
+        case $? in
+            0) ;; # integrity OK
+            1) return 1 ;;
+            2) # missing files
+                local force_version=
+                    if [ "$component" = BACKEND ]; then
+                    case "$VERSION" in
+                        dev|''|"1.1.0"|"v1.1.0") ;;
+                        *) force_version="-W $VERSION"
+                    esac
+                fi
+                log_msg "Updating qosmate $component..."
+                update -n -U "$UPD_CHANNEL" $force_version -c "$component" || return 1 ;;
+            3) ;; # non-matching md5sums
+        esac
+    done
+
     install_packages
     create_hotplug_script  # Create the hotplug script instead of downloading it
     check_and_download_config || return 1

--- a/etc/init.d/qosmate
+++ b/etc/init.d/qosmate
@@ -6,8 +6,8 @@ STOP=99
 
 USE_PROCD=1
 
-VERSION="13062ae883c58e2aa99040993af0f980e2092466"
-UPD_CHANNEL="snapshot"
+VERSION="dev"
+UPD_CHANNEL="release"
 
 EXTRA_COMMANDS="check_version update auto_setup expand_config auto_setup_noninteractive validate_custom_rules health_check"
 EXTRA_HELP="


### PR DESCRIPTION
Check and update both components on integrity failure during start
The start_service function now checks the file integrity for both BACKEND and FRONTEND components.

Previously, only the backend integrity was checked, and an update was triggered only if backend files were missing.